### PR TITLE
#15 관리자 페이지 추가 업데이트 

### DIFF
--- a/src/com/empty/admin/controller/AdminSearchTypeAjaxServlet.java
+++ b/src/com/empty/admin/controller/AdminSearchTypeAjaxServlet.java
@@ -19,7 +19,7 @@ import com.empty.member.model.vo.Member;
 /**
  * Servlet implementation class AdminSearchTypeServlet
  */
-@WebServlet("/admin/searchTypeAjax")
+@WebServlet("/admin/user/searchTypeAjax")
 public class AdminSearchTypeAjaxServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
        

--- a/src/com/empty/admin/controller/AdminUserAjaxPageServlet.java
+++ b/src/com/empty/admin/controller/AdminUserAjaxPageServlet.java
@@ -19,7 +19,7 @@ import com.empty.member.model.vo.Member;
 /**
  * Servlet implementation class AdminUserAjaxPageServlet
  */
-@WebServlet("/admin/ajaxPaging")
+@WebServlet("/admin/user/ajaxPaging")
 public class AdminUserAjaxPageServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
        

--- a/src/com/empty/admin/controller/RequestStoreApprServlet.java
+++ b/src/com/empty/admin/controller/RequestStoreApprServlet.java
@@ -37,6 +37,10 @@ public class RequestStoreApprServlet extends HttpServlet {
 		}else {
 			System.out.println("등록 실패");
 		}
+		request.setAttribute("msg", userId+" 유저의 스토어 승인이 완료되었습니다.");
+		request.setAttribute("loc", "/admin/store/requestStoreList");
+		request.setAttribute("locstr", "목록으로");
+		request.getRequestDispatcher("/views/admincommon/msg.jsp").forward(request, response);
 		
 	}
 

--- a/src/com/empty/admin/controller/RequestStoreListApprServlet.java
+++ b/src/com/empty/admin/controller/RequestStoreListApprServlet.java
@@ -1,23 +1,26 @@
 package com.empty.admin.controller;
 
 import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.empty.admin.model.service.AdminService;
+
 /**
- * Servlet implementation class AdminStoreGoServlet
+ * Servlet implementation class RequestStoreListApprServlet
  */
-@WebServlet("/admin/manageStore")
-public class AdminStoreGoServlet extends HttpServlet {
+@WebServlet("/admin/store/requestStoreListAppr")
+public class RequestStoreListApprServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
        
     /**
      * @see HttpServlet#HttpServlet()
      */
-    public AdminStoreGoServlet() {
+    public RequestStoreListApprServlet() {
         super();
         // TODO Auto-generated constructor stub
     }
@@ -26,9 +29,20 @@ public class AdminStoreGoServlet extends HttpServlet {
 	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
 	 */
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		// TODO Auto-generated method stub
+		String ids = request.getParameter("userid");
+		String [] userid = ids.split(", ");
+		for(String s : userid) {
+			System.out.println("아이디: "+s);
+		}
+		int result = new AdminService().updateAppr(userid);
+		
+		request.setAttribute("msg", result+"개의 스토어가 승인처리 되었습니다.");
+		request.setAttribute("loc", "/admin/store/requestStoreList");
+		request.setAttribute("locstr", "목록으로");
+		request.getRequestDispatcher("/views/admincommon/msg.jsp").forward(request, response);
 		
 		
-		request.getRequestDispatcher("/views/admin/store.jsp").forward(request, response);
 	}
 
 	/**

--- a/src/com/empty/admin/controller/StoreRunningAjaxPagingServlet.java
+++ b/src/com/empty/admin/controller/StoreRunningAjaxPagingServlet.java
@@ -1,0 +1,90 @@
+package com.empty.admin.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import com.empty.admin.model.service.AdminService;
+import com.google.gson.Gson;
+
+/**
+ * Servlet implementation class StoreRunningAjaxPagingServlet
+ */
+@WebServlet("/admin/store/runningStoreAjax")
+public class StoreRunningAjaxPagingServlet extends HttpServlet {
+	private static final long serialVersionUID = 1L;
+       
+    /**
+     * @see HttpServlet#HttpServlet()
+     */
+    public StoreRunningAjaxPagingServlet() {
+        super();
+        // TODO Auto-generated constructor stub
+    }
+
+	/**
+	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
+	 */
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		// TODO Auto-generated method stub
+		int cPage = Integer.parseInt(request.getParameter("cPage"));
+		int numPerPage = Integer.parseInt(request.getParameter("numPerPage"));
+		List list = new AdminService().selectStore(cPage,numPerPage);
+		
+		if(list.size()>0) {
+			int totalMember = new AdminService().selectStore();
+			int totalPage = (int)Math.ceil((double)totalMember/numPerPage);
+			int pageBarSize = 5;
+			int pageNo=((cPage-1)/pageBarSize)*pageBarSize+1;
+			int pageEnd = pageNo+pageBarSize-1;
+			String pageBar = "";
+			if(pageNo==1) {
+				pageBar+="<span class='nextBtn'style='color:grey'> ◀ 이전 </span>";
+			}else {
+				pageBar+="<a href='javascript:void(0);' onclick='requestStore("+(pageNo-1)+","+numPerPage+");'> ◀ 이전 </a>";
+				pageBar+="<a href='javascript:void(0);' onclick='requestStore("+1+","+numPerPage+");'>  1  </a>";
+				pageBar+="<span> ... </span>";
+			}
+			while(!(pageNo>pageEnd||pageNo>totalPage)) {
+				if(pageNo==cPage) {
+					pageBar+="<span class='cPage' style='color:#ff7531'> "+pageNo+" </span>";
+				}else {
+					pageBar+="<a href='javascript:void(0);' onclick='requestStore("+pageNo+","+numPerPage+");'> "+pageNo+" </a>";
+					
+				}
+				pageNo++;
+			}
+			if(pageNo>totalPage) {
+				pageBar+="<span class='nextBtn'style='color:grey'> 다음 ▶ </span>";
+			}else {
+				pageBar+="<span> ... </span>";
+				pageBar+="<a href='javascript:void(0);' onclick='requestStore("+totalPage+","+numPerPage+")'> "+totalPage+" </a>";
+				pageBar+="<a href='javascript:void(0);' onclick='requestStore("+pageNo+","+numPerPage+")'> 다음 ▶ <a>";
+			}
+			list.add(totalMember);
+			list.add(pageBar);
+			
+		}else {
+			list.add("검색된 결과가 없습니다.");
+		}
+		response.setContentType("application/json;charset=UTF-8");
+		new Gson().toJson(list,response.getWriter());
+		
+		
+		
+	}
+
+	/**
+	 * @see HttpServlet#doPost(HttpServletRequest request, HttpServletResponse response)
+	 */
+	protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		// TODO Auto-generated method stub
+		doGet(request, response);
+	}
+
+}

--- a/src/com/empty/admin/controller/StoreRunningDeleteServlet.java
+++ b/src/com/empty/admin/controller/StoreRunningDeleteServlet.java
@@ -1,23 +1,26 @@
 package com.empty.admin.controller;
 
 import java.io.IOException;
+
 import javax.servlet.ServletException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.empty.admin.model.service.AdminService;
+
 /**
- * Servlet implementation class AdminStoreGoServlet
+ * Servlet implementation class StoreRunningDeleteServlet
  */
-@WebServlet("/admin/manageStore")
-public class AdminStoreGoServlet extends HttpServlet {
+@WebServlet("/admin/store/deleteStore")
+public class StoreRunningDeleteServlet extends HttpServlet {
 	private static final long serialVersionUID = 1L;
        
     /**
      * @see HttpServlet#HttpServlet()
      */
-    public AdminStoreGoServlet() {
+    public StoreRunningDeleteServlet() {
         super();
         // TODO Auto-generated constructor stub
     }
@@ -26,9 +29,20 @@ public class AdminStoreGoServlet extends HttpServlet {
 	 * @see HttpServlet#doGet(HttpServletRequest request, HttpServletResponse response)
 	 */
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		// TODO Auto-generated method stub
+		String id = request.getParameter("userId");
+		int result = new AdminService().deleteStore(id);
+		
+		if(result>0) {
+			request.setAttribute("msg",id+"의 스토어가 삭제되었습니다.");
+			
+		}else {
+			request.setAttribute("msg", id+"의 스토어 삭제에 실패하였습니다.");
+		}
+		request.setAttribute("loc", "/admin/manageStore");
+		request.getRequestDispatcher("/views/admincommon/alert.jsp").forward(request, response);
 		
 		
-		request.getRequestDispatcher("/views/admin/store.jsp").forward(request, response);
 	}
 
 	/**

--- a/src/com/empty/admin/model/dao/AdminDao.java
+++ b/src/com/empty/admin/model/dao/AdminDao.java
@@ -8,11 +8,13 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
 import com.empty.member.model.vo.Member;
+import com.empty.search.model.vo.Store;
 
 public class AdminDao {
 	Properties prop = new Properties();
@@ -212,6 +214,99 @@ public class AdminDao {
 		}
 		
 		System.out.println("updateAppr: "+result);
+		return result;
+	}
+
+	public int updateAppr(Connection conn, String[] userid) {
+		PreparedStatement pstmt= null;
+		int result = 0;
+		String sql = prop.getProperty("updateAppr");
+		for(String s : userid) {
+			try {
+				
+				pstmt=conn.prepareStatement(sql);
+				pstmt.setString(1, s);
+				result+=pstmt.executeUpdate();
+			}catch(SQLException e) {
+				e.printStackTrace();
+			}finally {
+				close(pstmt);
+			}
+		}
+		
+		System.out.println("updateAppr: "+result);
+		return result;
+	}
+
+	public List<Store> selectStore(Connection conn, int cPage, int numPerPage) {
+		PreparedStatement pstmt = null;
+		ResultSet  rs = null;
+		List<Store> list = new ArrayList();
+		String sql = prop.getProperty("selectStore");
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setInt(1, (cPage-1)*numPerPage+1);
+			pstmt.setInt(2, cPage*numPerPage);
+			rs = pstmt.executeQuery();
+			while(rs.next()) {
+				Store s = new Store();
+				s.setStoreId(rs.getString("STORE_ID"));
+				s.setStoreName(rs.getString("STORE_NAME"));
+				s.setStorePhone(rs.getString("STORE_PHONE"));
+				s.setEmail(rs.getString("EMAIL"));
+				s.setStoreAddress(rs.getString("STORE_ADDRESS"));
+				SimpleDateFormat sdf = new SimpleDateFormat("yy.MM.dd");
+				String date = sdf.format(rs.getDate("ENROLLDATE"));
+				s.setEnrollDate(date);
+				list.add(s);
+				
+			}
+		}catch(SQLException e) {
+			e.printStackTrace();
+		}finally {
+			close(rs);
+			close(pstmt);
+		}
+		
+		return list;
+	}
+
+	public int selectStore(Connection conn) {
+		PreparedStatement pstmt = null;
+		ResultSet rs = null;
+		int result = 0;
+		String sql = prop.getProperty("countStore");
+		try {
+			pstmt=conn.prepareStatement(sql);
+			rs=pstmt.executeQuery();
+			if(rs.next()) {
+				result = rs.getInt(1);
+			}
+			
+		}catch(SQLException e) {
+			e.printStackTrace();
+		}finally {
+			close(rs);
+			close(pstmt);
+		}
+		return result;
+	}
+
+	public int deleteStore(Connection conn, String id) {
+
+		PreparedStatement pstmt = null;
+		
+		int result = 0;
+		String sql = prop.getProperty("deleteStore");
+		try {
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setString(1, id);
+			result = pstmt.executeUpdate();
+		}catch(SQLException e) {
+			e.printStackTrace();
+		}finally {
+			close(pstmt);
+		}
 		return result;
 	}
 	

--- a/src/com/empty/admin/model/service/AdminService.java
+++ b/src/com/empty/admin/model/service/AdminService.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import com.empty.admin.model.dao.AdminDao;
 import com.empty.member.model.vo.Member;
+import com.empty.search.model.vo.Store;
 
 public class AdminService {
 
@@ -65,6 +66,34 @@ public class AdminService {
 		close(conn);
 		return result;
 		
+	}
+	public int updateAppr(String[] userid) {
+		Connection conn = getConnection();
+		int result = dao.updateAppr(conn,userid);
+		if(result>0)commit(conn);
+		else rollback(conn);
+		return result;
+	}
+	public List<Store> selectStore(int cPage,int numPerPage) {
+		Connection conn = getConnection();
+		List<Store> list = dao.selectStore(conn,cPage,numPerPage);
+		close(conn);
+		return list;
+	}
+	public int selectStore() {
+		Connection conn = getConnection();
+		int result = dao.selectStore(conn);
+		close(conn);
+		return result;
+		
+	}
+	public int deleteStore(String id) {
+		Connection conn = getConnection();
+		int result = dao.deleteStore(conn,id);
+		if (result>0) commit(conn);
+		else rollback(conn);
+		close(conn);
+		return result;
 	}
 	
 	

--- a/src/com/empty/search/model/vo/Store.java
+++ b/src/com/empty/search/model/vo/Store.java
@@ -10,7 +10,12 @@ public class Store {
 	private String storeFacility;
 	private String storeAddress;
 	private String storeLogo;
+	private String email;
+	private String enrollDate;
 	
+	
+	
+
 	public Store() {
 		// TODO Auto-generated constructor stub
 	}
@@ -79,11 +84,27 @@ public class Store {
 		this.storeLogo = storeLogo;
 	}
 
+	public String getEmail() {
+		return email;
+	}
+
+	public void setEmail(String email) {
+		this.email = email;
+	}
+
+	public String getEnrollDate() {
+		return enrollDate;
+	}
+
+	public void setEnrollDate(String enrollDate) {
+		this.enrollDate = enrollDate;
+	}
+
 	@Override
 	public String toString() {
 		return "Store [storeId=" + storeId + ", storeName=" + storeName + ", storePhone=" + storePhone + ", storeTime="
 				+ storeTime + ", storeInfo=" + storeInfo + ", storeFacility=" + storeFacility + ", storeAddress="
-				+ storeAddress + ", storeLogo=" + storeLogo + "]";
+				+ storeAddress + ", storeLogo=" + storeLogo + ", email=" + email + ", enrollDate=" + enrollDate + "]";
 	}
 
 	public Store(String storeId, String storeName, String storePhone, String storeTime, String storeInfo,
@@ -98,7 +119,20 @@ public class Store {
 		this.storeAddress = storeAddress;
 		this.storeLogo = storeLogo;
 	}
-	
+	public Store(String storeId, String storeName, String storePhone, String storeTime, String storeInfo,
+			String storeFacility, String storeAddress, String storeLogo, String email, String enrollDate) {
+		super();
+		this.storeId = storeId;
+		this.storeName = storeName;
+		this.storePhone = storePhone;
+		this.storeTime = storeTime;
+		this.storeInfo = storeInfo;
+		this.storeFacility = storeFacility;
+		this.storeAddress = storeAddress;
+		this.storeLogo = storeLogo;
+		this.email = email;
+		this.enrollDate = enrollDate;
+	}
 	
 	
 /*    STORE_ID VARCHAR2(40) PRIMARY KEY,

--- a/web/css/adminPage/admin.css
+++ b/web/css/adminPage/admin.css
@@ -174,7 +174,7 @@ select.searchBox{
 
 }
 .contentTable>thead tr{
-	background-color:#ff7531;
+	background-color:#e6e8eb;
 }
 .contentTable th{
 	border-left:none;

--- a/web/css/adminPage/msg.css
+++ b/web/css/adminPage/msg.css
@@ -1,0 +1,29 @@
+#msgContainer{
+    text-align: center;
+    vertical-align: middle;
+    position: relative;
+    margin: 100px 10%;
+    border: 3px solid  rgb(242,242,242);
+    height: 200px;
+}
+#msgContainer>div:first-child{
+    margin-top:50px;
+}
+#msgContainer>div:nth-child(2){
+    margin-top:30px;
+}
+#msgContainer>div>h4{
+    font-size: 20px;
+    font-weight: normal;
+}
+#msgContainer button{
+    border: none;
+    width:140px;
+    height: 38px;
+    outline: none;
+    border: none;
+    background-color: black;
+    color: white;
+    
+    
+}

--- a/web/css/adminPage/store.css
+++ b/web/css/adminPage/store.css
@@ -62,3 +62,4 @@ select{
 	
 }
 .apprBtn_{height:25px;background-color:white;color:black;outline:none;border: black solid 1px;}
+#allAppr{width:80px;height:30px;background-color:black;color:white;outline:none;border: black solid 1px;font-size:14px;margin:10px 0 0 5px;}

--- a/web/js/adminPage/store.js
+++ b/web/js/adminPage/store.js
@@ -3,3 +3,58 @@ function storeAppr(){
 		
 		location.href="/EMPTY/admin/store/requestAppr?userId="+id;
 	}
+$(function(){
+    $("#allCheck").click(function(){
+        allCheckFunc($(this));
+        var one = $(".chkone")
+         
+        console.log(one);
+        
+    })
+    
+})
+function oneCheck(){
+   
+    oneCheckFunc(event.target);
+    
+}
+function allCheckFunc(obj){
+    $(".chkone").prop("checked",$(obj).prop("checked"));
+}
+function oneCheckFunc(obj){
+    
+    var allObj = $("#allCheck");
+    var objName = $(obj).attr("name");
+   if($(obj).prop("checked")){
+       checkBoxLength = $("[name="+objName+"]").length;
+       checkedLength = $("[name="+objName+"]:checked").length;
+//       console.log(checkBoxLength);
+//       console.log(checkedLength);
+       if(checkBoxLength ==checkedLength){
+           allObj.prop("checked",true);
+       }else{
+           allObj.prop("checked",false);
+       }
+   }else{
+       allObj.prop("checked",false);
+   }
+
+}   
+
+function idPlus(){
+	var str = "";
+	$(".chkone").each(function(){
+		if($(this).is(":checked")){
+			
+			str += $(this).val()+", ";
+		}
+	})
+	 console.log(str);
+	$("#submitIds").val(str);
+	$("#apprSubmit").submit();
+}
+function deleteStore(){
+	var id = $(event.target).val();
+	location.href="/EMPTY/admin/store/deleteStore?userId="+id;
+	
+}

--- a/web/views/admin/manageUser.jsp
+++ b/web/views/admin/manageUser.jsp
@@ -154,7 +154,7 @@
 		function requestData(cPage,numPerPage){
 			console.log("기본 페이징처리");
             	$.ajax({
-            	url:"<%=request.getContextPath()%>/admin/store/ajaxPaging",
+            	url:"<%=request.getContextPath()%>/admin/user/ajaxPaging",
 				dataType : "json",
 				type : "get",
 				data : {"cPage" :cPage,"numPerPage" :numPerPage},

--- a/web/views/admin/searchUser.jsp
+++ b/web/views/admin/searchUser.jsp
@@ -170,7 +170,7 @@
 
 		function searchKeyType (type,key,cPage,numPerPage){
 			$.ajax({
-				url:"<%=request.getContextPath()%>/admin/searchTypeAjax",
+				url:"<%=request.getContextPath()%>/admin/user/searchTypeAjax",
 				dataType : "json",
 				type : "get",
 				data : {"searchType":type,"searchKeyword":key,"cPage" :cPage,"numPerPage" :numPerPage},

--- a/web/views/admin/store.jsp
+++ b/web/views/admin/store.jsp
@@ -10,8 +10,9 @@
 
 		<div id="storeSubMenu">
 			<ul>
-				<li><a href="#"><span class="text-item">스토어 이용현황</span></a></li>
+				<li><a href="<%=request.getContextPath()%>/admin/manageStore"><span class="text-item">스토어 이용현황</span></a></li>
 				<li><a href="<%=request.getContextPath()%>/admin/store/requestStoreList"><span class="text-item">스토어 신청현황</span></a></li>
+				<li><a href="#"><span class="text-item">스토어 매출보기</span></a></li>
 			</ul>
 		</div>
 		
@@ -21,6 +22,7 @@
 	</div>
 	<div id="primaryContent">
 		<div>
+			<span id="totalSearch"></span>
 			<form>
 				<input type="hidden" name="cPage" value="" id="cPage"> <select
 					name="numPerPage" id="numPerPage">
@@ -36,31 +38,17 @@
 			<thead>
 				<tr>
 					<th class="chk"><input id="allCheck" type="checkbox" value=""></th>
-					<th class="userid_">아이디</th>
-					<th class="username_">신청이름</th>
+					<th class="userid_">스토어 아이디</th>
+					<th class="username_">스토어 명</th>
 					<th class="phone_">전화번호</th>
 					<th class="email_" nowrap="nowrap">이메일</th>
 					<th class="addr_" nowrap="nowrap">주소</th>
 					<th class="enrolldate_" nowrap="nowrap">신청 일자</th>
-
+					<th class="" nowrap="nowrap">관리</th>
 				</tr>
 			</thead>
 			<tbody id="tbody">
 
-				<%--<%for(Member m : list){ %>
-                            <tr class="myarticle">
-                            	<th class="chk"><input id="allCheck" type="checkbox" value=""></th>
-                                <th class="userid_"><%=m.getUserId()%></th>
-                                <th class="userdiv_"><%=m.isUserDiv()%></th>
-                                <th class="username_"><%=m.getusername()%></th>
-                                <th class="gender_"><%=m.getGender()%></th>
-                                <th class="phone_"><%=m.getPhone()%></th>
-                                <th class="email_" ><%=m.getEmail()%></th>
-                                <th class="addr_" ><%=m.getAddress()%></th>
-                                <th class="enrolldate_" ><%=m.getEnrollDate()%></th>
-                                
-							</tr>
-                            <%} %>     --%>
 			</tbody>
 		</table>
 		<!-- end bbsList -->
@@ -69,15 +57,63 @@
 	<!-- paging -->
 	<div class="list_btn_area">
 		<div class="paging"></div>
-		<button></button>
+		
 
 	</div>
-
-
-
-
-	<!-- content end -->
-
-
-
 </section>
+<script type="text/javascript" src="<%=request.getContextPath()%>/js/base.js"></script>
+<script type="text/javascript" src="<%=request.getContextPath()%>/js/adminPage/store.js"></script>
+<script>
+$(function(){
+	runningStore(1,10);
+})
+function runningStore(cPage,numPerPage){
+	$.ajax({
+		url:"<%=request.getContextPath()%>/admin/store/runningStoreAjax",
+		dataType:"json",
+		type:"post",
+		data:{"cPage":cPage,"numPerPage":numPerPage},
+		success:function(data){
+			console.log(data);
+			console.log(data[data.length-1]);
+			console.log(data[data.length-2]);
+			if(data.length>1){
+				const tbody = $("#tbody");
+				
+				for(let i = 0;i<data.length-2;i++){
+					const tr =$("<tr>");
+				 	tr.append($("<td>").append($("<input>").attr({name:"dataid",type:"checkbox",class:"chkone",value:data[i]['storeId'],onclick:""})));	
+					tr.append($("<td>").html(data[i]['storeId']).addClass("userid_"));
+					tr.append($("<td>").html(data[i]['storeName']).addClass("username_"));
+					tr.append($("<td>").html(data[i]['storePhone']).addClass("phone_"));
+					tr.append($("<td>").html(data[i]['email']).addClass("email_"));
+					tr.append($("<td>").html(data[i]['storeAddress']).addClass("address_"));
+					tr.append($("<td>").html(data[i]['enrollDate']).addClass("enrolldate_"));
+					tr.append($("<td>").append($("<button>").addClass("apprBtn_").html("스토어 삭제하기").attr({type:"button",onclick:"deleteStore();",value:data[i]['storeId']})));
+					i ==0?tbody.html(tr):tbody.append(tr);
+					
+				}
+				$(".paging").html(data[data.length-1]);//페이지바
+				$("#totalSearch").html("검색 결과: "+data[data.length-2]+ "개 입니다.");//총검색결과
+				
+			  
+			}else{
+				$(".paging").html(data[0]);
+			}
+		
+			
+		},
+		error: function(request,status,error){
+			if (request.status == 404){
+				
+				console.log("페이지를 찾을 수 없습니다.");
+				$(".paging").html("페이지를 찾을 수 없습니다.");
+			}
+		}
+	})
+}
+
+
+</script>
+
+

--- a/web/views/admin/storeRequestList.jsp
+++ b/web/views/admin/storeRequestList.jsp
@@ -10,8 +10,9 @@
 
 		<div id="storeSubMenu">
 			<ul>
-				<li><a href="#"><span class="text-item">스토어 이용현황</span></a></li>
+				<li><a href="<%=request.getContextPath() %>/admin/manageStore"><span class="text-item">스토어 이용현황</span></a></li>
 				<li><a href="<%=request.getContextPath()%>/admin/store/requestStoreList"><span class="text-item">스토어 신청현황</span></a></li>
+				<li><a href="#"><span class="text-item">스토어 매출보기</span></a></li>
 			</ul>
 		</div>
 		
@@ -23,8 +24,8 @@
 		<div>
 			<span id="totalSearch"></span>
 			<form>
-				<input type="hidden" name="cPage" value="" id="cPage"> <select
-					name="numPerPage" id="numPerPage">
+				<input type="hidden" name="cPage" value="" id="cPage"> 
+				<select name="numPerPage" id="numPerPage">
 					<option value="10">목록 10개</option>
 					<option value="20">목록 20개</option>
 					<option value="30">목록 30개</option>
@@ -52,7 +53,11 @@
 			</tbody>
 		</table>
 		<!-- end bbsList -->
-		<button>수락하기</button>
+		<form action="<%=request.getContextPath()%>/admin/store/requestStoreListAppr" method="post" id="apprSubmit">
+			<input id="submitIds" type="hidden" name="userid">
+			<button type="button" id="allAppr" onclick="idPlus();">수락하기</button>
+			
+		</form>
 	</div>
 	<!-- paging -->
 	<div class="list_btn_area">
@@ -82,7 +87,7 @@
 					
 					for(let i = 0;i<data.length-2;i++){
 						const tr =$("<tr>");
-					 	tr.append($("<td>").append($("<input>").attr({name:"dataid",type:"checkbox",class:"chkone",value:data[i]['userId']})));	
+					 	tr.append($("<td>").append($("<input>").attr({name:"dataid",type:"checkbox",class:"chkone",value:data[i]['userId'],onclick:"oneCheck();"})));	
 						tr.append($("<td>").html(data[i]['userId']).addClass("userid_"));
 						tr.append($("<td>").html(data[i]['userName']).addClass("username_"));
 						tr.append($("<td>").html(data[i]['phone']).addClass("phone_"));
@@ -95,6 +100,8 @@
 					}
 					$(".paging").html(data[data.length-1]);//페이지바
 					$("#totalSearch").html("검색 결과: "+data[data.length-2]+ "개 입니다.");//총검색결과
+					
+				  
 				}else{
 					$(".paging").html(data[0]);
 				}

--- a/web/views/admincommon/alert.jsp
+++ b/web/views/admincommon/alert.jsp
@@ -1,0 +1,24 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8"
+    pageEncoding="UTF-8"%>
+    
+    <%
+    	String msg =(String)request.getAttribute("msg");
+    	String loc = (String)request.getAttribute("loc");
+    
+    %>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+</head>
+<body>
+	<script>
+		alert('<%=msg%>');
+		
+		location.replace("<%=request.getContextPath()%><%=loc%>");
+	
+	</script>
+	
+</body>
+</html>

--- a/web/views/admincommon/msg.jsp
+++ b/web/views/admincommon/msg.jsp
@@ -1,12 +1,38 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
-    pageEncoding="UTF-8"%>
-<!DOCTYPE html>
-<html>
-<head>
-<meta charset="UTF-8">
-<title>Insert title here</title>
-</head>
-<body>
+	pageEncoding="UTF-8"%>
+<%@ include file="/views/admincommon/header.jsp"%>
+<%
+	String msg = (String)request.getAttribute("msg");
+	String locstr = (String)request.getAttribute("locstr");
+	String loc = (String)request.getAttribute("loc");
 
-</body>
-</html>
+%>
+<link rel="stylesheet" href="<%=request.getContextPath() %>/css/adminPage/msg.css" type="text/css">
+
+<section>
+
+	<div id="msgContainer">
+		<div>
+			<h4><%=msg %></h4>
+		</div>
+		<div>
+			<a>
+				<button type="button" id="wantloc"><%=locstr %></button>
+			</a> 
+			<a>
+				<button type="button" id="mainloc">메인화면으로</button>
+			</a>
+		</div>
+	</div>
+
+</section>
+<script>
+	$("#wantloc").click(function(){
+		location.replace("<%=request.getContextPath()%><%=loc%>");
+	})
+	$("#mainloc").click(function(){
+		location.replace("<%=request.getContextPath()%>/");
+	})
+	
+
+</script>


### PR DESCRIPTION
스토어 조회, 스토어 신청 수락(전체수락 가능)

남은것- 스토어 신청 수락시 해당 이메일로 메일 발송 
회원 삭제, 스토어 삭제, 스토어 검색 
가능하다면 스토어 일매출 월매출 보기

스토어 마이페이지 : 영업시작 영업 마감 클릭시 일매출 db에 추가update되는것 (현재매출 조회시에는 select문으로)
관리자 커뮤니티 탭애서 스토어계정과 슈퍼관리자간의 실시간 채팅 (가능하다면)
